### PR TITLE
CocoaPodsをサポート

### DIFF
--- a/NetworkInfo.podspec
+++ b/NetworkInfo.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name = 'NetworkInfo'
+  s.version = '0.0.1'
+  s.summary = 'Network information in Swift.'
+  s.homepage = 'https://github.com/mike-neko/NetworkInfo'
+  s.license = 'MIT'
+  s.author = 'mike-neko'
+  
+  s.ios.deployment_target = '9.2'
+  
+  s.source = { :git => 'https://github.com/mike-neko/NetworkInfo.git', :tag => s.version.to_s }
+  s.source_files = 'Sources/*.{swift}'
+  
+  s.requires_arc = true
+  s.library       = 'c'
+  s.preserve_path = 'libc/*'
+  s.pod_target_xcconfig = { 'SWIFT_INCLUDE_PATHS' => '$(PODS_ROOT)/NetworkInfo/libc' }
+end

--- a/NetworkInfo.xcodeproj/project.pbxproj
+++ b/NetworkInfo.xcodeproj/project.pbxproj
@@ -7,28 +7,67 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0E9657FE1E07F28D0070D5FF /* InterfaceAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9657FD1E07F28D0070D5FF /* InterfaceAddress.swift */; };
 		0EB1039E1C8DA344001C5FE7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB1039D1C8DA344001C5FE7 /* AppDelegate.swift */; };
 		0EB103A01C8DA344001C5FE7 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB1039F1C8DA344001C5FE7 /* ViewController.swift */; };
 		0EB103A31C8DA344001C5FE7 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0EB103A11C8DA344001C5FE7 /* Main.storyboard */; };
 		0EB103A51C8DA344001C5FE7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0EB103A41C8DA344001C5FE7 /* Assets.xcassets */; };
 		0EB103A81C8DA344001C5FE7 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0EB103A61C8DA344001C5FE7 /* LaunchScreen.storyboard */; };
+		B878E0B71E41F91D003CAB8D /* NetworkInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = B878E0B51E41F91D003CAB8D /* NetworkInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B878E0C21E41FAC2003CAB8D /* InterfaceAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = B878E0C11E41FAC2003CAB8D /* InterfaceAddress.swift */; };
+		B878E0C81E41FC84003CAB8D /* NetworkInfo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B878E0B31E41F91D003CAB8D /* NetworkInfo.framework */; };
+		B878E0C91E41FC84003CAB8D /* NetworkInfo.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B878E0B31E41F91D003CAB8D /* NetworkInfo.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		B878E0CA1E41FC84003CAB8D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0EB103921C8DA344001C5FE7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B878E0B21E41F91D003CAB8D;
+			remoteInfo = NetworkInfo;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		B878E0CC1E41FC84003CAB8D /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				B878E0C91E41FC84003CAB8D /* NetworkInfo.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
-		0E9657FD1E07F28D0070D5FF /* InterfaceAddress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceAddress.swift; sourceTree = "<group>"; };
-		0EB1039A1C8DA344001C5FE7 /* NetworkInfo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NetworkInfo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		0EB1039A1C8DA344001C5FE7 /* iOS Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "iOS Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0EB1039D1C8DA344001C5FE7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0EB1039F1C8DA344001C5FE7 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		0EB103A21C8DA344001C5FE7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		0EB103A41C8DA344001C5FE7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0EB103A71C8DA344001C5FE7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		0EB103A91C8DA344001C5FE7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		0EB103B11C8DA391001C5FE7 /* NetworkInfo-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NetworkInfo-Bridging-Header.h"; sourceTree = "<group>"; };
+		B878E0B31E41F91D003CAB8D /* NetworkInfo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NetworkInfo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B878E0B51E41F91D003CAB8D /* NetworkInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkInfo.h; sourceTree = "<group>"; };
+		B878E0B61E41F91D003CAB8D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B878E0C11E41FAC2003CAB8D /* InterfaceAddress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceAddress.swift; sourceTree = "<group>"; };
+		B878E0C61E41FBD0003CAB8D /* include.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = include.h; sourceTree = "<group>"; };
+		B878E0C71E41FBD0003CAB8D /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		0EB103971C8DA344001C5FE7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B878E0C81E41FC84003CAB8D /* NetworkInfo.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B878E0AF1E41F91D003CAB8D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -41,7 +80,8 @@
 		0EB103911C8DA344001C5FE7 = {
 			isa = PBXGroup;
 			children = (
-				0EB1039C1C8DA344001C5FE7 /* NetworkInfo */,
+				0EB1039C1C8DA344001C5FE7 /* iOS Example */,
+				B878E0B41E41F91D003CAB8D /* NetworkInfo */,
 				0EB1039B1C8DA344001C5FE7 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -49,36 +89,95 @@
 		0EB1039B1C8DA344001C5FE7 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				0EB1039A1C8DA344001C5FE7 /* NetworkInfo.app */,
+				0EB1039A1C8DA344001C5FE7 /* iOS Example.app */,
+				B878E0B31E41F91D003CAB8D /* NetworkInfo.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		0EB1039C1C8DA344001C5FE7 /* NetworkInfo */ = {
+		0EB1039C1C8DA344001C5FE7 /* iOS Example */ = {
 			isa = PBXGroup;
 			children = (
 				0EB1039D1C8DA344001C5FE7 /* AppDelegate.swift */,
 				0EB1039F1C8DA344001C5FE7 /* ViewController.swift */,
-				0EB103B11C8DA391001C5FE7 /* NetworkInfo-Bridging-Header.h */,
-				0E9657FD1E07F28D0070D5FF /* InterfaceAddress.swift */,
 				0EB103A11C8DA344001C5FE7 /* Main.storyboard */,
 				0EB103A41C8DA344001C5FE7 /* Assets.xcassets */,
 				0EB103A61C8DA344001C5FE7 /* LaunchScreen.storyboard */,
 				0EB103A91C8DA344001C5FE7 /* Info.plist */,
 			);
+			name = "iOS Example";
 			path = NetworkInfo;
 			sourceTree = "<group>";
 		};
+		B878E0B41E41F91D003CAB8D /* NetworkInfo */ = {
+			isa = PBXGroup;
+			children = (
+				B878E0B51E41F91D003CAB8D /* NetworkInfo.h */,
+				B878E0B61E41F91D003CAB8D /* Info.plist */,
+				B878E0C01E41FAC2003CAB8D /* Sources */,
+				B878E0C51E41FBD0003CAB8D /* libc */,
+			);
+			path = NetworkInfo;
+			sourceTree = "<group>";
+		};
+		B878E0C01E41FAC2003CAB8D /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				B878E0C11E41FAC2003CAB8D /* InterfaceAddress.swift */,
+			);
+			path = Sources;
+			sourceTree = SOURCE_ROOT;
+		};
+		B878E0C51E41FBD0003CAB8D /* libc */ = {
+			isa = PBXGroup;
+			children = (
+				B878E0C61E41FBD0003CAB8D /* include.h */,
+				B878E0C71E41FBD0003CAB8D /* module.modulemap */,
+			);
+			path = libc;
+			sourceTree = SOURCE_ROOT;
+		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		B878E0B01E41F91D003CAB8D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B878E0B71E41F91D003CAB8D /* NetworkInfo.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
-		0EB103991C8DA344001C5FE7 /* NetworkInfo */ = {
+		0EB103991C8DA344001C5FE7 /* iOS Example */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 0EB103AC1C8DA344001C5FE7 /* Build configuration list for PBXNativeTarget "NetworkInfo" */;
+			buildConfigurationList = 0EB103AC1C8DA344001C5FE7 /* Build configuration list for PBXNativeTarget "iOS Example" */;
 			buildPhases = (
 				0EB103961C8DA344001C5FE7 /* Sources */,
 				0EB103971C8DA344001C5FE7 /* Frameworks */,
 				0EB103981C8DA344001C5FE7 /* Resources */,
+				B878E0CC1E41FC84003CAB8D /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B878E0CB1E41FC84003CAB8D /* PBXTargetDependency */,
+			);
+			name = "iOS Example";
+			productName = NetworkInfo;
+			productReference = 0EB1039A1C8DA344001C5FE7 /* iOS Example.app */;
+			productType = "com.apple.product-type.application";
+		};
+		B878E0B21E41F91D003CAB8D /* NetworkInfo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B878E0BC1E41F91D003CAB8D /* Build configuration list for PBXNativeTarget "NetworkInfo" */;
+			buildPhases = (
+				B878E0AE1E41F91D003CAB8D /* Sources */,
+				B878E0AF1E41F91D003CAB8D /* Frameworks */,
+				B878E0B01E41F91D003CAB8D /* Headers */,
+				B878E0B11E41F91D003CAB8D /* Resources */,
 			);
 			buildRules = (
 			);
@@ -86,8 +185,8 @@
 			);
 			name = NetworkInfo;
 			productName = NetworkInfo;
-			productReference = 0EB1039A1C8DA344001C5FE7 /* NetworkInfo.app */;
-			productType = "com.apple.product-type.application";
+			productReference = B878E0B31E41F91D003CAB8D /* NetworkInfo.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
@@ -96,12 +195,16 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = M.Ike;
 				TargetAttributes = {
 					0EB103991C8DA344001C5FE7 = {
 						CreatedOnToolsVersion = 7.2.1;
 						LastSwiftMigration = 0810;
+					};
+					B878E0B21E41F91D003CAB8D = {
+						CreatedOnToolsVersion = 8.2.1;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -118,7 +221,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				0EB103991C8DA344001C5FE7 /* NetworkInfo */,
+				0EB103991C8DA344001C5FE7 /* iOS Example */,
+				B878E0B21E41F91D003CAB8D /* NetworkInfo */,
 			);
 		};
 /* End PBXProject section */
@@ -134,6 +238,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B878E0B11E41F91D003CAB8D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -141,13 +252,28 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0E9657FE1E07F28D0070D5FF /* InterfaceAddress.swift in Sources */,
 				0EB103A01C8DA344001C5FE7 /* ViewController.swift in Sources */,
 				0EB1039E1C8DA344001C5FE7 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B878E0AE1E41F91D003CAB8D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B878E0C21E41FAC2003CAB8D /* InterfaceAddress.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		B878E0CB1E41FC84003CAB8D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B878E0B21E41F91D003CAB8D /* NetworkInfo */;
+			targetProxy = B878E0CA1E41FC84003CAB8D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		0EB103A11C8DA344001C5FE7 /* Main.storyboard */ = {
@@ -182,8 +308,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -226,8 +354,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -246,6 +376,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -253,13 +384,14 @@
 		0EB103AD1C8DA344001C5FE7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = NetworkInfo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.mikeneko-app.NetworkInfo";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mikeneko-app.iOS-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "NetworkInfo/NetworkInfo-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 			};
@@ -268,14 +400,73 @@
 		0EB103AE1C8DA344001C5FE7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = NetworkInfo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mikeneko-app.iOS-Example";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+		B878E0BD1E41F91D003CAB8D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = NetworkInfo/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mikeneko-app.NetworkInfo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "NetworkInfo/NetworkInfo-Bridging-Header.h";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = libc;
 				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		B878E0BE1E41F91D003CAB8D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = NetworkInfo/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mikeneko-app.NetworkInfo";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_INCLUDE_PATHS = libc;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};
@@ -291,7 +482,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		0EB103AC1C8DA344001C5FE7 /* Build configuration list for PBXNativeTarget "NetworkInfo" */ = {
+		0EB103AC1C8DA344001C5FE7 /* Build configuration list for PBXNativeTarget "iOS Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				0EB103AD1C8DA344001C5FE7 /* Debug */,
@@ -299,6 +490,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		B878E0BC1E41F91D003CAB8D /* Build configuration list for PBXNativeTarget "NetworkInfo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B878E0BD1E41F91D003CAB8D /* Debug */,
+				B878E0BE1E41F91D003CAB8D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/NetworkInfo/Base.lproj/Main.storyboard
+++ b/NetworkInfo/Base.lproj/Main.storyboard
@@ -1,24 +1,28 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="25z-1f-Xh7">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="25z-1f-Xh7">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--IP Address-->
         <scene sceneID="ILy-i8-zRh">
             <objects>
-                <tableViewController id="cL5-Cv-FOQ" customClass="ViewController" customModule="NetworkInfo" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="cL5-Cv-FOQ" customClass="ViewController" customModule="iOS_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="T4M-2L-FfM">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TableViewCell" textLabel="nYg-m2-RfL" detailTextLabel="OfB-uE-Jo6" style="IBUITableViewCellStyleSubtitle" id="MWZ-bq-CD6">
-                                <rect key="frame" x="0.0" y="92" width="600" height="44"/>
+                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="MWZ-bq-CD6" id="cOF-m8-ZPr">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="nYg-m2-RfL">
@@ -47,7 +51,7 @@
                     <navigationItem key="navigationItem" title="IP Address" id="LhK-Rw-eDy">
                         <barButtonItem key="rightBarButtonItem" systemItem="refresh" id="IBb-7s-dU9">
                             <connections>
-                                <action selector="tapUpdate:" destination="cL5-Cv-FOQ" id="rjw-9b-zJ6"/>
+                                <action selector="tapUpdateWithSender:" destination="cL5-Cv-FOQ" id="fXo-q5-BJN"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>

--- a/NetworkInfo/Info.plist
+++ b/NetworkInfo/Info.plist
@@ -13,28 +13,16 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>APPL</string>
+	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
-	<key>UISupportedInterfaceOrientations</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
 </dict>
 </plist>

--- a/NetworkInfo/NetworkInfo-Bridging-Header.h
+++ b/NetworkInfo/NetworkInfo-Bridging-Header.h
@@ -1,7 +1,0 @@
-//
-//  Use this file to import your target's public headers that you would like to expose to Swift.
-//
-
-#include <ifaddrs.h>
-#include <sys/socket.h>
-#include <netinet/in.h>

--- a/NetworkInfo/NetworkInfo.h
+++ b/NetworkInfo/NetworkInfo.h
@@ -1,0 +1,19 @@
+//
+//  NetworkInfo.h
+//  NetworkInfo
+//
+//  Created by Yu Sugawara on 2/1/17.
+//  Copyright © 2017 M.Ike. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for NetworkInfo.
+FOUNDATION_EXPORT double NetworkInfoVersionNumber;
+
+//! Project version string for NetworkInfo.
+FOUNDATION_EXPORT const unsigned char NetworkInfoVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <NetworkInfo/PublicHeader.h>
+
+

--- a/NetworkInfo/ViewController.swift
+++ b/NetworkInfo/ViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import NetworkInfo
 
 class ViewController: UITableViewController {
     

--- a/Sources/InterfaceAddress.swift
+++ b/Sources/InterfaceAddress.swift
@@ -7,28 +7,29 @@
 //
 
 import Foundation
+import libc
 
 //- Requires: #include <ifaddrs.h> <sys/socket.h> <netinet/in.h>
 
-class InterfaceAddress {
-    enum Network: String {
+public class InterfaceAddress {
+    public enum Network: String {
         case localWiFi = "en0"
         case wan = "pdp_ip0"
     }
     
-    enum Version: String {
+    public enum Version: String {
         case IPv4
         case IPv6
         
-        func toString() -> String {
+        public func toString() -> String {
             return self.rawValue
         }
     }
     
-    let name: String
-    let version: Version
-    let IP: String
-    let mask: String
+    public let name: String
+    public let version: Version
+    public let IP: String
+    public let mask: String
     
     private init(name: String, version: Version, IP: String, mask: String) {
         self.name = name
@@ -37,7 +38,7 @@ class InterfaceAddress {
         self.mask = mask
     }
     
-    static func list() -> [InterfaceAddress]? {
+    public static func list() -> [InterfaceAddress]? {
         var results = [InterfaceAddress]()
         var ifaList: UnsafeMutablePointer<ifaddrs>? = nil
         
@@ -134,7 +135,7 @@ class InterfaceAddress {
         }
     }
     
-    static func address(network: Network, version: Version) -> InterfaceAddress? {
+    public static func address(network: Network, version: Version) -> InterfaceAddress? {
         return list()?.filter { $0.name == network.rawValue && $0.version == version }.first
     }
 }

--- a/libc/include.h
+++ b/libc/include.h
@@ -1,0 +1,3 @@
+#include <ifaddrs.h>
+#include <sys/socket.h>
+#include <netinet/in.h>

--- a/libc/module.modulemap
+++ b/libc/module.modulemap
@@ -1,0 +1,4 @@
+module libc [system] {
+    header "include.h"
+    export *
+}


### PR DESCRIPTION
CocoaPodsをサポートしました。

主な変更点として、CocoaPodsはFrameworkにBridging-Headerを含むことができないので、NetworkInfo-Bridging-Header.hを削除して、libcのモジュールを含むFrameworkにしました。